### PR TITLE
Creates generic class DatastoreHelper to handle datastore calls

### DIFF
--- a/portfolio/src/main/java/com/google/sps/data/ContactMeMessage.java
+++ b/portfolio/src/main/java/com/google/sps/data/ContactMeMessage.java
@@ -1,10 +1,5 @@
 package com.google.sps.data;
 
-import java.util.ArrayList;
-
-import com.google.cloud.datastore.Entity;
-import com.google.cloud.datastore.QueryResults;
-
 public class ContactMeMessage {
     private final long id;
     private final long timestamp;
@@ -23,25 +18,6 @@ public class ContactMeMessage {
         this.email = email;
         this.message = message;
         this.id = 0;
-    }
-
-    public static ArrayList<ContactMeMessage> createList(QueryResults<Entity> results){
-        ArrayList<ContactMeMessage> list = new ArrayList<>();
-        
-        while(results.hasNext()){
-            list.add(entityConverter(results.next()));
-        }
-
-        return list;
-    }
-
-    public static ContactMeMessage entityConverter(Entity entity){
-        long id = entity.getKey().getId();
-        long timestamp = entity.getLong("timestamp");
-        String email = entity.getString("email");
-        String message = entity.getString("message");
-
-        return new ContactMeMessage(id, timestamp, email, message);
     }
 
     public long getId(){

--- a/portfolio/src/main/java/com/google/sps/data/ContactMeMessage.java
+++ b/portfolio/src/main/java/com/google/sps/data/ContactMeMessage.java
@@ -1,5 +1,10 @@
 package com.google.sps.data;
 
+import java.util.ArrayList;
+
+import com.google.cloud.datastore.Entity;
+import com.google.cloud.datastore.QueryResults;
+
 public class ContactMeMessage {
     private final long id;
     private final long timestamp;
@@ -11,6 +16,32 @@ public class ContactMeMessage {
         this.timestamp = timestamp;
         this.email = email;
         this.message = message;
+    }
+
+    public ContactMeMessage(long timestamp, String email, String message){
+        this.timestamp = timestamp;
+        this.email = email;
+        this.message = message;
+        this.id = 0;
+    }
+
+    public static ArrayList<ContactMeMessage> createList(QueryResults<Entity> results){
+        ArrayList<ContactMeMessage> list = new ArrayList<>();
+        
+        while(results.hasNext()){
+            list.add(entityConverter(results.next()));
+        }
+
+        return list;
+    }
+
+    public static ContactMeMessage entityConverter(Entity entity){
+        long id = entity.getKey().getId();
+        long timestamp = entity.getLong("timestamp");
+        String email = entity.getString("email");
+        String message = entity.getString("message");
+
+        return new ContactMeMessage(id, timestamp, email, message);
     }
 
     public long getId(){

--- a/portfolio/src/main/java/com/google/sps/servlets/ContactMeServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/ContactMeServlet.java
@@ -14,7 +14,7 @@ import org.jsoup.safety.Whitelist;
 
 @WebServlet("/contact-me")
 public class ContactMeServlet extends HttpServlet{
-    private final DatastoreHelper<ContactMeMessage> helper = new DatastoreContactMe("Message");
+    private final DatastoreHelper<ContactMeMessage> helper = new DatastoreContactMe();
 
     @Override
     public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException{

--- a/portfolio/src/main/java/com/google/sps/servlets/ContactMeServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/ContactMeServlet.java
@@ -13,6 +13,7 @@ import org.jsoup.safety.Whitelist;
 
 @WebServlet("/contact-me")
 public class ContactMeServlet extends HttpServlet{
+    private final DatastoreHelper<ContactMeMessage> helper = new DatastoreHelper<>("Message");
 
     @Override
     public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException{
@@ -20,7 +21,6 @@ public class ContactMeServlet extends HttpServlet{
         String message = Jsoup.clean(request.getParameter("message"), Whitelist.none());
         long timestamp = System.currentTimeMillis();
 
-        DatastoreHelper<ContactMeMessage> helper = new DatastoreHelper<>("Message");
         ContactMeMessage newMessage = new ContactMeMessage(timestamp, email, message);
         helper.put(newMessage);
         

--- a/portfolio/src/main/java/com/google/sps/servlets/ContactMeServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/ContactMeServlet.java
@@ -5,11 +5,9 @@ import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import com.google.cloud.datastore.DatastoreOptions;
-import com.google.cloud.datastore.Entity;
-import com.google.cloud.datastore.FullEntity;
-import com.google.cloud.datastore.Datastore;
-import com.google.cloud.datastore.KeyFactory;
+import com.google.sps.data.ContactMeMessage;
+import com.google.sps.storage.DatastoreHelper;
+
 import org.jsoup.Jsoup;
 import org.jsoup.safety.Whitelist;
 
@@ -17,21 +15,15 @@ import org.jsoup.safety.Whitelist;
 public class ContactMeServlet extends HttpServlet{
 
     @Override
-    public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
+    public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException{
         String email = Jsoup.clean(request.getParameter("email"), Whitelist.none());
         String message = Jsoup.clean(request.getParameter("message"), Whitelist.none());
         long timestamp = System.currentTimeMillis();
 
-        Datastore datastore = DatastoreOptions.getDefaultInstance().getService();
-        KeyFactory keyFactory = datastore.newKeyFactory().setKind("Message");
-        FullEntity messageEntity = 
-            Entity.newBuilder(keyFactory.newKey())
-                .set("email", email)
-                .set("message", message)
-                .set("timestamp", timestamp)
-                .build();
-
-        datastore.put(messageEntity);
+        DatastoreHelper<ContactMeMessage> helper = new DatastoreHelper<>("Message");
+        ContactMeMessage newMessage = new ContactMeMessage(timestamp, email, message);
+        helper.put(newMessage);
+        
         System.out.printf("Email: %s\nMessage: %s\n", email, message);
         response.sendRedirect("/confirm.html");
     }

--- a/portfolio/src/main/java/com/google/sps/servlets/ContactMeServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/ContactMeServlet.java
@@ -6,6 +6,7 @@ import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import com.google.sps.data.ContactMeMessage;
+import com.google.sps.storage.DatastoreContactMe;
 import com.google.sps.storage.DatastoreHelper;
 
 import org.jsoup.Jsoup;
@@ -13,7 +14,7 @@ import org.jsoup.safety.Whitelist;
 
 @WebServlet("/contact-me")
 public class ContactMeServlet extends HttpServlet{
-    private final DatastoreHelper<ContactMeMessage> helper = new DatastoreHelper<>("Message");
+    private final DatastoreHelper<ContactMeMessage> helper = new DatastoreContactMe("Message");
 
     @Override
     public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException{

--- a/portfolio/src/main/java/com/google/sps/servlets/ListContactMeServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/ListContactMeServlet.java
@@ -2,47 +2,21 @@ package com.google.sps.servlets;
 
 import java.io.IOException;
 import java.util.ArrayList;
-
 import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-
-import com.google.cloud.datastore.Query;
-import com.google.cloud.datastore.QueryResults;
-import com.google.cloud.datastore.Datastore;
-import com.google.cloud.datastore.DatastoreOptions;
-import com.google.cloud.datastore.Entity;
-import com.google.cloud.datastore.StructuredQuery.OrderBy;
 import com.google.gson.Gson;
 import com.google.sps.data.ContactMeMessage;
+import com.google.sps.storage.DatastoreHelper;
 
 @WebServlet("/list-contact-me")
 public class ListContactMeServlet extends HttpServlet{
 
     @Override
     public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException{
-        Datastore datastore = DatastoreOptions.getDefaultInstance().getService();
-        Query<Entity> query = Query.newEntityQueryBuilder()
-                                .setKind("Message")
-                                .setOrderBy(OrderBy.desc("timestamp"))
-                                .build();
-        QueryResults<Entity> results = datastore.run(query);
-
-        ArrayList<ContactMeMessage> messages = new ArrayList<>();
-        
-        while (results.hasNext()){
-            Entity entity = results.next();
-
-            long id = entity.getKey().getId();
-            long timestamp = entity.getLong("timestamp");
-            String email = entity.getString("email");
-            String message = entity.getString("message");
-        
-            ContactMeMessage contactMeMessage = new ContactMeMessage(id, timestamp, email, message);
-
-            messages.add(contactMeMessage);
-        }
+        DatastoreHelper<ContactMeMessage> helper = new DatastoreHelper<>("Message");
+        ArrayList<ContactMeMessage> messages = ContactMeMessage.createList(helper.queryAll("timestamp"));
 
         Gson gson = new Gson();
 

--- a/portfolio/src/main/java/com/google/sps/servlets/ListContactMeServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/ListContactMeServlet.java
@@ -10,16 +10,17 @@ import javax.servlet.http.HttpServletResponse;
 import com.google.cloud.datastore.StructuredQuery.OrderBy;
 import com.google.gson.Gson;
 import com.google.sps.data.ContactMeMessage;
+import com.google.sps.storage.DatastoreContactMe;
 import com.google.sps.storage.DatastoreHelper;
 
 @WebServlet("/list-contact-me")
 public class ListContactMeServlet extends HttpServlet{
-    private final DatastoreHelper<ContactMeMessage> helper = new DatastoreHelper<>("Message");
+    private final DatastoreHelper<ContactMeMessage> helper = new DatastoreContactMe("Message");
 
     @Override
     public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException{
-        ArrayList<ContactMeMessage> messages = ContactMeMessage.createList(helper.queryAll(OrderBy.desc("timestamp")));
-
+        ArrayList<ContactMeMessage> messages = helper.listFromQuery(helper.queryAll(OrderBy.desc("timestamp")));
+        
         Gson gson = new Gson();
 
         response.setContentType("application/json");

--- a/portfolio/src/main/java/com/google/sps/servlets/ListContactMeServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/ListContactMeServlet.java
@@ -15,7 +15,7 @@ import com.google.sps.storage.DatastoreHelper;
 
 @WebServlet("/list-contact-me")
 public class ListContactMeServlet extends HttpServlet{
-    private final DatastoreHelper<ContactMeMessage> helper = new DatastoreContactMe("Message");
+    private final DatastoreHelper<ContactMeMessage> helper = new DatastoreContactMe();
 
     @Override
     public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException{

--- a/portfolio/src/main/java/com/google/sps/servlets/ListContactMeServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/ListContactMeServlet.java
@@ -14,10 +14,10 @@ import com.google.sps.storage.DatastoreHelper;
 
 @WebServlet("/list-contact-me")
 public class ListContactMeServlet extends HttpServlet{
+    private final DatastoreHelper<ContactMeMessage> helper = new DatastoreHelper<>("Message");
 
     @Override
     public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException{
-        DatastoreHelper<ContactMeMessage> helper = new DatastoreHelper<>("Message");
         ArrayList<ContactMeMessage> messages = ContactMeMessage.createList(helper.queryAll(OrderBy.desc("timestamp")));
 
         Gson gson = new Gson();

--- a/portfolio/src/main/java/com/google/sps/servlets/ListContactMeServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/ListContactMeServlet.java
@@ -6,6 +6,8 @@ import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+
+import com.google.cloud.datastore.StructuredQuery.OrderBy;
 import com.google.gson.Gson;
 import com.google.sps.data.ContactMeMessage;
 import com.google.sps.storage.DatastoreHelper;
@@ -16,7 +18,7 @@ public class ListContactMeServlet extends HttpServlet{
     @Override
     public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException{
         DatastoreHelper<ContactMeMessage> helper = new DatastoreHelper<>("Message");
-        ArrayList<ContactMeMessage> messages = ContactMeMessage.createList(helper.queryAll("timestamp"));
+        ArrayList<ContactMeMessage> messages = ContactMeMessage.createList(helper.queryAll(OrderBy.desc("timestamp")));
 
         Gson gson = new Gson();
 

--- a/portfolio/src/main/java/com/google/sps/servlets/ListContactMeServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/ListContactMeServlet.java
@@ -19,7 +19,7 @@ public class ListContactMeServlet extends HttpServlet{
 
     @Override
     public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException{
-        ArrayList<ContactMeMessage> messages = helper.listFromQuery(helper.queryAll(OrderBy.desc("timestamp")));
+        ArrayList<ContactMeMessage> messages = helper.queryAll(OrderBy.desc("timestamp"));
         
         Gson gson = new Gson();
 

--- a/portfolio/src/main/java/com/google/sps/storage/DatastoreContactMe.java
+++ b/portfolio/src/main/java/com/google/sps/storage/DatastoreContactMe.java
@@ -1,17 +1,15 @@
 package com.google.sps.storage;
 
-import java.util.ArrayList;
-
 import com.google.cloud.datastore.Entity;
-import com.google.cloud.datastore.QueryResults;
 import com.google.sps.data.ContactMeMessage;
 
 public class DatastoreContactMe extends DatastoreHelper<ContactMeMessage> {
 
-    public DatastoreContactMe(String kind) {
-        super(kind);
+    public DatastoreContactMe() {
+        super("Message");
     }
 
+    @Override
     public ContactMeMessage convertEntity(Entity entity) {
         long id = entity.getKey().getId();
         long timestamp = entity.getLong("timestamp");
@@ -21,14 +19,4 @@ public class DatastoreContactMe extends DatastoreHelper<ContactMeMessage> {
         return new ContactMeMessage(id, timestamp, email, message);
     }
     
-    public ArrayList<ContactMeMessage> listFromQuery(QueryResults<Entity> results){
-        ArrayList<ContactMeMessage> list = new ArrayList<>();
-        
-        while(results.hasNext()){
-            list.add(convertEntity(results.next()));
-        }
-
-        return list;
-    }
-
 }

--- a/portfolio/src/main/java/com/google/sps/storage/DatastoreContactMe.java
+++ b/portfolio/src/main/java/com/google/sps/storage/DatastoreContactMe.java
@@ -1,0 +1,34 @@
+package com.google.sps.storage;
+
+import java.util.ArrayList;
+
+import com.google.cloud.datastore.Entity;
+import com.google.cloud.datastore.QueryResults;
+import com.google.sps.data.ContactMeMessage;
+
+public class DatastoreContactMe extends DatastoreHelper<ContactMeMessage> {
+
+    public DatastoreContactMe(String kind) {
+        super(kind);
+    }
+
+    public ContactMeMessage convertEntity(Entity entity) {
+        long id = entity.getKey().getId();
+        long timestamp = entity.getLong("timestamp");
+        String email = entity.getString("email");
+        String message = entity.getString("message");
+
+        return new ContactMeMessage(id, timestamp, email, message);
+    }
+    
+    public ArrayList<ContactMeMessage> listFromQuery(QueryResults<Entity> results){
+        ArrayList<ContactMeMessage> list = new ArrayList<>();
+        
+        while(results.hasNext()){
+            list.add(convertEntity(results.next()));
+        }
+
+        return list;
+    }
+
+}

--- a/portfolio/src/main/java/com/google/sps/storage/DatastoreHelper.java
+++ b/portfolio/src/main/java/com/google/sps/storage/DatastoreHelper.java
@@ -1,0 +1,68 @@
+package com.google.sps.storage;
+
+import com.google.cloud.datastore.Datastore;
+import com.google.cloud.datastore.DatastoreOptions;
+import com.google.cloud.datastore.Entity;
+import com.google.cloud.datastore.FullEntity;
+import com.google.cloud.datastore.IncompleteKey;
+import com.google.cloud.datastore.KeyFactory;
+import com.google.cloud.datastore.Query;
+import com.google.cloud.datastore.QueryResults;
+import com.google.cloud.datastore.StructuredQuery.OrderBy;
+
+import java.lang.reflect.*;
+
+public class DatastoreHelper <T>{
+    Datastore datastore;
+    KeyFactory keyFactory;
+    String kind;
+
+    public DatastoreHelper(String kind){
+        this.kind = kind;
+        datastore = DatastoreOptions.getDefaultInstance().getService();
+        keyFactory = datastore.newKeyFactory().setKind(kind);
+    }
+
+    public void put(T element){
+        Class<?> classType= element.getClass();
+        Field[] fields = classType.getDeclaredFields();
+
+        FullEntity.Builder<IncompleteKey> entityBuilder = Entity.newBuilder(keyFactory.newKey());
+
+        for (Field field: fields){
+            if(field.getName() == "id")
+                continue;
+            field.setAccessible(true);
+            Class<?> fieldType = field.getType();
+            try{
+                if(fieldType.isPrimitive()){
+                    entityBuilder.set(field.getName(), (long) field.get(element));                
+                }
+                else if(fieldType == String.class){
+                    entityBuilder.set(field.getName(), (String) field.get(element));
+                }
+            }
+            catch(IllegalAccessException e){
+                System.out.printf("IllegalAccessException while trying to get value of field %s in class %s",
+                    field.getName(),
+                    classType.getName());
+            }   
+        }
+        FullEntity<?> entity = entityBuilder.build();
+        datastore.put(entity);
+    }
+
+    public QueryResults<Entity> queryAll() {
+        Query<Entity> query = Query.newEntityQueryBuilder().setKind(kind).build();
+        return datastore.run(query);
+    }
+
+    public QueryResults<Entity> queryAll(String order) {
+        Query<Entity> query = Query.newEntityQueryBuilder().setKind(kind)
+                                .setOrderBy(OrderBy.desc(order))
+                                .build();
+        return datastore.run(query);
+    }
+
+
+}

--- a/portfolio/src/main/java/com/google/sps/storage/DatastoreHelper.java
+++ b/portfolio/src/main/java/com/google/sps/storage/DatastoreHelper.java
@@ -24,6 +24,10 @@ public class DatastoreHelper <T>{
     }
 
     public void put(T element){
+        datastore.put(toEntity(element));
+    }
+
+    FullEntity<?> toEntity(T element){
         Class<?> classType= element.getClass();
         Field[] fields = classType.getDeclaredFields();
 
@@ -48,8 +52,7 @@ public class DatastoreHelper <T>{
                     classType.getName());
             }   
         }
-        FullEntity<?> entity = entityBuilder.build();
-        datastore.put(entity);
+        return entityBuilder.build();
     }
 
     public QueryResults<Entity> queryAll() {

--- a/portfolio/src/main/java/com/google/sps/storage/DatastoreHelper.java
+++ b/portfolio/src/main/java/com/google/sps/storage/DatastoreHelper.java
@@ -29,7 +29,16 @@ public abstract class DatastoreHelper <T>{
     }
 
     protected abstract T convertEntity(Entity entity);
-    public abstract ArrayList<T> listFromQuery(QueryResults<Entity> results);
+
+    public ArrayList<T> listFromQuery(QueryResults<Entity> results){
+        ArrayList<T> list = new ArrayList<>();
+        
+        while(results.hasNext()){
+            list.add(convertEntity(results.next()));
+        }
+
+        return list;
+    }
 
     private FullEntity<?> toEntity(T element){
         Class<?> classType= element.getClass();
@@ -70,6 +79,5 @@ public abstract class DatastoreHelper <T>{
                                 .build();
         return datastore.run(query);
     }
-
-
+    
 }

--- a/portfolio/src/main/java/com/google/sps/storage/DatastoreHelper.java
+++ b/portfolio/src/main/java/com/google/sps/storage/DatastoreHelper.java
@@ -13,9 +13,9 @@ import com.google.cloud.datastore.StructuredQuery.OrderBy;
 import java.lang.reflect.*;
 
 public class DatastoreHelper <T>{
-    Datastore datastore;
-    KeyFactory keyFactory;
-    String kind;
+    private final Datastore datastore;
+    private final KeyFactory keyFactory;
+    private final String kind;
 
     public DatastoreHelper(String kind){
         this.kind = kind;

--- a/portfolio/src/main/java/com/google/sps/storage/DatastoreHelper.java
+++ b/portfolio/src/main/java/com/google/sps/storage/DatastoreHelper.java
@@ -68,16 +68,16 @@ public abstract class DatastoreHelper <T>{
         return entityBuilder.build();
     }
 
-    public QueryResults<Entity> queryAll() {
+    public ArrayList<T> queryAll() {
         Query<Entity> query = Query.newEntityQueryBuilder().setKind(kind).build();
-        return datastore.run(query);
+        return listFromQuery(datastore.run(query));
     }
 
-    public QueryResults<Entity> queryAll(OrderBy order, OrderBy ... others) {
+    public ArrayList<T> queryAll(OrderBy order, OrderBy ... others) {
         Query<Entity> query = Query.newEntityQueryBuilder().setKind(kind)
                                 .setOrderBy(order, others)
                                 .build();
-        return datastore.run(query);
+        return listFromQuery(datastore.run(query));
     }
     
 }

--- a/portfolio/src/main/java/com/google/sps/storage/DatastoreHelper.java
+++ b/portfolio/src/main/java/com/google/sps/storage/DatastoreHelper.java
@@ -57,9 +57,9 @@ public class DatastoreHelper <T>{
         return datastore.run(query);
     }
 
-    public QueryResults<Entity> queryAll(String order) {
+    public QueryResults<Entity> queryAll(OrderBy order, OrderBy ... others) {
         Query<Entity> query = Query.newEntityQueryBuilder().setKind(kind)
-                                .setOrderBy(OrderBy.desc(order))
+                                .setOrderBy(order, others)
                                 .build();
         return datastore.run(query);
     }

--- a/portfolio/src/main/java/com/google/sps/storage/DatastoreHelper.java
+++ b/portfolio/src/main/java/com/google/sps/storage/DatastoreHelper.java
@@ -11,8 +11,9 @@ import com.google.cloud.datastore.QueryResults;
 import com.google.cloud.datastore.StructuredQuery.OrderBy;
 
 import java.lang.reflect.*;
+import java.util.ArrayList;
 
-public class DatastoreHelper <T>{
+public abstract class DatastoreHelper <T>{
     private final Datastore datastore;
     private final KeyFactory keyFactory;
     private final String kind;
@@ -27,7 +28,10 @@ public class DatastoreHelper <T>{
         datastore.put(toEntity(element));
     }
 
-    FullEntity<?> toEntity(T element){
+    protected abstract T convertEntity(Entity entity);
+    public abstract ArrayList<T> listFromQuery(QueryResults<Entity> results);
+
+    private FullEntity<?> toEntity(T element){
         Class<?> classType= element.getClass();
         Field[] fields = classType.getDeclaredFields();
 


### PR DESCRIPTION
As recommended in the previous pull request:
- Built a generic class to handle calls to the datastore API.
- Added a method that transforms an entity into a ContactMeMessage object.
- Added a method that receives the query and turns it into al list of ContactMeMessage objects.

In the future, I can use the DatastoreHelper class for other entities, since the class is generic and uses reflection - which I learned today. It was a difficult concept but I understand it now :D 